### PR TITLE
v1.2.9 - Fix thema_sort_order

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Plugin voor het aanmaken van de 'thema'-taxonomie
 
 
 ## Current version:
-* 1.2.8 - Sorting corrected.
+* 1.2.9 - Fix thema_sort_order
 
 ## Version history
+* 1.2.9 - Fix thema_sort_order
 * 1.2.8 - Sorting corrected.
 * 1.2.7 - Add sorting order, and display term info on thema detail page.
 * 1.2.6 - Renamed Constants to reflect GC preference

--- a/ictuwp-plugin-thema-taxonomie.php
+++ b/ictuwp-plugin-thema-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Thema taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie
  * Description:         Plugin voor het aanmaken van de 'thema'-taxonomie
- * Version:             1.2.8
- * Version description: Sorting corrected.
+ * Version:             1.2.9
+ * Version description: Fix thema_sort_order
  * Author:              Paul van Buuren
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie/
  * License:             GPL-2.0+

--- a/includes/register-thema-taxonomy.php
+++ b/includes/register-thema-taxonomy.php
@@ -136,14 +136,14 @@ function fn_ictu_thema_get_thema_terms( $thema_name = null, $term_args = null ) 
 		'taxonomy'   => $thema_taxonomy,
 		// We also want Terms with NO linked content, in this case
 		'hide_empty' => false,
-		// sort by our custom numerical `thema_sort_order` field
-		// ASC (so lower == first)
-		// If equal/unset, sort by Title ASC
+		// sort by our custom numerical `thema_sort_order` field ASC (so lower == first)
+		// With equal values, we would *like* to sort alphabetically (on `name`), but that's not possible :(
+		// So: with equal sort order, we sort by `term_id` (which is the order in which they were created)
 		'order'      => 'ASC',
 		'orderby'    => 'meta_value_num',
 		'meta_key'   => 'thema_sort_order',
+		'meta_type'  => 'NUMERIC', // sort numerically, even if `thema_sort_order` is stored as String
 	];
-
 
 	// Query specific term name
 	if ( ! empty( $thema_name ) ) {
@@ -163,6 +163,8 @@ function fn_ictu_thema_get_thema_terms( $thema_name = null, $term_args = null ) 
 			foreach ( get_fields( $thema_term ) as $key => $val ) {
 				$thema_term->$key = $val;
 			}
+			// DEBUG: prefix name with term_id and thema_sort_order
+			// $thema_term->name = $thema_term->term_id . '-' . $thema_term->thema_sort_order . '-' . $thema_term->name;
 			$thema_terms[] = $thema_term;
 		}
 	}


### PR DESCRIPTION
Sorting on `thema_sort_order` **AND** `name` does not work. Now only(!) sorting on `thema_sort_order`.
When `thema_sort_order` is equal, sorting falls back to `ID` ASC