### PR TITLE
1.2.15 - Add Term `url` property to allow linking to coupled page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version history
+* 1.2.15 - Add Term `url` property to allow linking to coupled page.
 * 1.2.14 - Updated and checked correct use of translations.
 * 1.2.13 - GC-533: Read-more links microcopy.
 * 1.2.12 - Bugfix for ACF fields in a group.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Plugin voor het aanmaken van de 'thema'-taxonomie
 
 
 ## Current version:
-* 1.2.14 - Updated and checked correct use of translations.
+* 1.2.15 - Add Term `url` property to allow linking to coupled page.
 
 ## Changelog:
+* 1.2.14 - Updated and checked correct use of translations.
 * 1.2.12 - Bugfix for ACF fields in a group.
 
 ## To do

--- a/ictuwp-plugin-thema-taxonomie.php
+++ b/ictuwp-plugin-thema-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Thema taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie
  * Description:         Plugin voor het aanmaken van de 'thema'-taxonomie
- * Version:             1.2.14
- * Version description: Updated and checked correct use of translations.
+ * Version:             1.2.15
+ * Version description: Add Term `url` property to allow linking to coupled page.
  * Author:              Paul van Buuren
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie/
  * License:             GPL-2.0+

--- a/includes/register-thema-taxonomy.php
+++ b/includes/register-thema-taxonomy.php
@@ -161,6 +161,11 @@ function fn_ictu_thema_get_thema_terms( $thema_name = null, $term_args = null ) 
 		// And add to $thema_terms[]
 		foreach ( $found_thema_terms as $thema_term ) {
 			foreach ( get_fields( $thema_term ) as $key => $val ) {
+				// If we have a linked Page, add it's URL to the Term as extra `url` property
+				if( $key == 'thema_taxonomy_page' && ! empty( $val ) ) {
+					$thema_term->url = get_permalink( $val );
+				}
+				// Add our custom ACF fields to this WP_Term..
 				$thema_term->$key = $val;
 			}
 			// DEBUG: prefix name with term_id and thema_sort_order


### PR DESCRIPTION
Needed for e.g. linking a `.tag` to the Term landingpage