### PR TITLE
v1.2.18 - Optimize `metabox_posts_archive_selection` for Archive Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version history
+* 1.2.18 - Optimize `metabox_posts_archive_selection` for Archive Link
 * 1.2.17 - Fix regession re: `fn_ictu_thema_get_thema_terms()`
 * 1.2.16 - Make title translatable.
 * 1.2.15 - Add Term `url` property to allow linking to coupled page.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Plugin voor het aanmaken van de 'thema'-taxonomie
 
 
 ## Current version:
-* 1.2.17 - Fix regession re: `fn_ictu_thema_get_thema_terms()`
+* 1.2.18 - Optimize `metabox_posts_archive_selection` for Archive Link
 
 ## Changelog:
+* 1.2.17 - Fix regession re: `fn_ictu_thema_get_thema_terms()`
 * 1.2.16 - Make title translatable.
 * 1.2.15 - Add Term `url` property to allow linking to coupled page.
 * 1.2.14 - Updated and checked correct use of translations.

--- a/ictuwp-plugin-thema-taxonomie.php
+++ b/ictuwp-plugin-thema-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Thema taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie
  * Description:         Plugin voor het aanmaken van de 'thema'-taxonomie
- * Version:             1.2.17
- * Version description: Fix regession re: `fn_ictu_thema_get_thema_terms()`
+ * Version:             1.2.18
+ * Version description: Optimize `metabox_posts_archive_selection` for Archive Link
  * Author:              Paul van Buuren
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie/
  * License:             GPL-2.0+
@@ -96,6 +96,23 @@ if ( ! class_exists( 'ICTU_GC_thema_taxonomy' ) ) :
 
 			// check if the term has detail page attached
 			add_action( 'template_redirect', array( $this, 'fn_ictu_thema_check_redirect' ) );
+
+			// Hide the `metabox_posts_category` field for 'community' related posts
+			// (because we already filter on Community tax term)
+			add_filter( 'acf/prepare_field/name=metabox_posts_category', function( $field ) {
+				global $post;
+				if ( ! empty( $post ) ) {
+					// Check if we're currently editing a post
+					// with a Thema template.
+					// If so: *disable* the category selection (return false)
+					// because we use the Thema Tax...
+					$page_template = get_post_meta( $post->ID, '_wp_page_template', true );
+					if ( $page_template === GC_THEMA_TAX_DETAIL_TEMPLATE ) {
+						return false;
+					}
+				}
+				return $field;
+			} );
 
 		}
 

--- a/template-thema-detail.php
+++ b/template-thema-detail.php
@@ -73,6 +73,8 @@ if ( class_exists( 'EM_Events' ) ) {
 		$maxnr         = 3; // todo TBD: should this be a user editable field?
 		$metabox_items = array();
 
+		// TODO: why is this 'manualxx'?
+		// FIXME: manualxx will never match? Even when user _has_ selected events manually?
 		if ( 'manualxx' === $method ) {
 			// manually selected events, returns an array of posts
 			$metabox_items = $metabox_fields['metabox_events_selection_manual'];
@@ -344,7 +346,12 @@ if ( $metabox_fields && 'ja' === $metabox_fields['metabox_posts_show_or_not'] ) 
 		$metabox_items = $metabox_fields['metabox_posts_selection_manual'];
 
 	} else {
-		$args        = array(
+		// Check: do we want posts from a certain category?
+		if ( array_key_exists( 'metabox_posts_category', $metabox_fields ) ) {
+			$metabox_posts_category = $metabox_fields['metabox_posts_category'];
+		}
+
+		$args = array(
 			'posts_per_page' => $maxnr,
 			'post_type'      => 'post',
 			'post_status'    => 'publish',
@@ -357,6 +364,18 @@ if ( $metabox_fields && 'ja' === $metabox_fields['metabox_posts_show_or_not'] ) 
 				)
 			)
 		);
+
+		// If we have a post category, add it to the Tax query
+		// we do not only query on Thema Tax, but on Post Category as well
+		if ( ! empty( $metabox_posts_category ) ) {
+			$args['tax_query']['relation'] = 'AND';
+			$args['tax_query'][] = array(
+				'taxonomy' => 'category',
+				'field'    => 'term_id',
+				'terms'    => $metabox_posts_category,
+			);
+		}
+
 		$query_items = new WP_Query( $args );
 		if ( $query_items->have_posts() ) {
 			// we only use post ids for the $metabox_items array
@@ -374,42 +393,55 @@ if ( $metabox_fields && 'ja' === $metabox_fields['metabox_posts_show_or_not'] ) 
 		$context['metabox_posts']['cta']         = [];
 		$context['metabox_posts']['title']       = $metabox_fields['metabox_posts_titel'] ?? '';
 		$context['metabox_posts']['description'] = $metabox_fields['metabox_posts_description'] ?? '';
-		$url                                     = $metabox_fields['metabox_posts_url_overview'] ?? [];
+		$archive_link_method                     = $metabox_fields['metabox_posts_archive_selection'] ?? [];
 
-		// Add click through link for all posts
-		if ( $url && ( 'manual' === $method ) ) {
-			// manually added CTA 'overzichtslink'
-			$context['metabox_posts']['cta']['title'] = $url['title'];
-			$context['metabox_posts']['cta']['url']   = $url['url'];
-		} else {
-			// automagically add link to LLK page for posts
-			$template = 'template-llk-posts.php';
-			$pages    = get_posts( array(
-				'post_type'  => 'page',
-				'fields'     => 'ids',
-				'meta_key'   => '_wp_page_template',
-				'meta_value' => $template
-			) );
-
-			if ( $pages && $pages[0] ) {
-				// a relevant LLK page was found
-
-				$context['metabox_posts']['cta']['title'] = _x( 'Lees alle artikelen', 'Linktekst voor LLK pagina met berichten', 'gctheme' );
-
-				// see if we can add GC_THEMA_TAX as extra filter
+		// $archive_link_method can be:
+		// none : Geen link
+		// automatic : Automatische link naar taxonomie archief
+		// custom : Geheel eigen link
+		if ( ! empty( $archive_link_method ) && $archive_link_method !== 'none' ) {
+			// Automatic Archive Link:
+			if ( 'automatic' === $archive_link_method ) {
+				// Based on Taxonomy (category [default] | Community | Thema), so check if it's not empty..
+				// NOTE: user could ALSO have selected a Post Category
+				// ..but we ignore this for the archive link and use the Thema archive here...
 				$term_info = get_term_by( 'id', $current_thema_taxid, GC_THEMA_TAX );
+				if ( ( $term_info && ! is_wp_error( $term_info ) ) ) {
 
-				if ( $term_info && ! is_wp_error( $term_info ) ) {
-					// append thema slug to LLK link
-					$item_url_vars                          = [ GC_QUERYVAR_THEMA => $term_info->slug ];
-					$context['metabox_posts']['cta']['url'] = add_query_arg( $item_url_vars, get_permalink( $pages[0] ) );
-				} else {
-					// just use the permalink
-					$context['metabox_posts']['cta']['url'] = get_permalink( $pages[0] );
+					$metabox_posts_category_name = $term_info->name;
+					$metabox_posts_category_text = $metabox_fields['metabox_posts_archive_selection_automatic_link_text'] ?: _x( 'Bekijk alle berichten', 'Linktekst voor Community berichten', 'gctheme' );
+
+					// Replace placeholder with term name in automatic link text
+					$metabox_posts_category_text = sprintf( $metabox_posts_category_text, $metabox_posts_category_name );
+
+					// automagically add link to LLK page for posts
+					$template = 'template-llk-posts.php';
+					$pages    = get_posts( array(
+						'post_type'  => 'page',
+						'fields'     => 'ids',
+						'meta_key'   => '_wp_page_template',
+						'meta_value' => $template
+					) );
+
+					if ( $pages && $pages[0] ) {
+						// a relevant LLK page was found
+						// see if we can add GC_THEMA_TAX as extra filter
+						$item_url_vars               = [ GC_QUERYVAR_THEMA => $term_info->slug ];
+						$metabox_posts_category_link = add_query_arg( $item_url_vars, get_permalink( $pages[0] ) );
+					}
+
+					$context['metabox_posts']['cta']['title'] = $metabox_posts_category_text;
+					$context['metabox_posts']['cta']['url']   = $metabox_posts_category_link;
 				}
-			} else {
-				// no manual link added, no page found.
-				// so: no link
+			}
+
+			// Custom Archive Link:
+			if ( 'custom' === $archive_link_method ) {
+				$custom_archive_link = $metabox_fields['metabox_posts_archive_selection_custom_link'];
+				if ( ! empty( $custom_archive_link ) ) {
+					$context['metabox_posts']['cta']['title'] = $custom_archive_link['title'] ?: _x( 'Bekijk alle berichten', 'Linktekst voor Community berichten', 'gctheme' );
+					$context['metabox_posts']['cta']['url']   = $custom_archive_link['url'];
+				}
 			}
 		}
 

--- a/template-thema-detail.php
+++ b/template-thema-detail.php
@@ -346,10 +346,14 @@ if ( $metabox_fields && 'ja' === $metabox_fields['metabox_posts_show_or_not'] ) 
 		$metabox_items = $metabox_fields['metabox_posts_selection_manual'];
 
 	} else {
-		// Check: do we want posts from a certain category?
-		if ( array_key_exists( 'metabox_posts_category', $metabox_fields ) ) {
-			$metabox_posts_category = $metabox_fields['metabox_posts_category'];
-		}
+
+		// Disabled: we disabled the `metabox_posts_category` field
+		// for Thema templates. We never want to query on category, only on Thema
+		// ---
+		// // Check: do we want posts from a certain category?
+		// if ( array_key_exists( 'metabox_posts_category', $metabox_fields ) ) {
+		// 	$metabox_posts_category = $metabox_fields['metabox_posts_category'];
+		// }
 
 		$args = array(
 			'posts_per_page' => $maxnr,
@@ -365,16 +369,19 @@ if ( $metabox_fields && 'ja' === $metabox_fields['metabox_posts_show_or_not'] ) 
 			)
 		);
 
-		// If we have a post category, add it to the Tax query
-		// we do not only query on Thema Tax, but on Post Category as well
-		if ( ! empty( $metabox_posts_category ) ) {
-			$args['tax_query']['relation'] = 'AND';
-			$args['tax_query'][] = array(
-				'taxonomy' => 'category',
-				'field'    => 'term_id',
-				'terms'    => $metabox_posts_category,
-			);
-		}
+		// Disabled: we disabled the `metabox_posts_category` field
+		// for Thema templates. We never want to query on category, only on Thema
+		// ---
+		// // If we have a post category, add it to the Tax query
+		// // we do not only query on Thema Tax, but on Post Category as well
+		// if ( ! empty( $metabox_posts_category ) ) {
+		// 	$args['tax_query']['relation'] = 'AND';
+		// 	$args['tax_query'][] = array(
+		// 		'taxonomy' => 'category',
+		// 		'field'    => 'term_id',
+		// 		'terms'    => $metabox_posts_category,
+		// 	);
+		// }
 
 		$query_items = new WP_Query( $args );
 		if ( $query_items->have_posts() ) {


### PR DESCRIPTION
In het kader van https://jira.ictu-sd.nl/jira/browse/GC-586 willen we een betere keuze voor een "Alle artikelen" link naar het archief. Voor thema's is dat de LLK pagina met het thema-filter (en _niet_ een core category archief!)