### PR TITLE
Lowercase the 1st character of the Thema tax name in archive link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version history
+* 2.0.1 - Lowercase the 1st character of the Thema tax name in archive link text
 * 2.0.0 - Refactor for Timber v2
 * 1.2.20 - Force new version
 * 1.2.19 - Fixed a sorting order bug.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Plugin voor het aanmaken van de 'thema'-taxonomie
 
 
 ## Current version:
-* 2.0.0 - Refactor for Timber v2
+* 2.0.1 - Lowercase the 1st character of the Thema tax name in archive link text
 
 ## Changelog:
+* 2.0.0 - Refactor for Timber v2
 * 1.2.20 - Force new version
 * 1.2.19 - Fixed a sorting order bug.
 * 1.2.18 - Optimize `metabox_posts_archive_selection` for Archive Link

--- a/ictuwp-plugin-thema-taxonomie.php
+++ b/ictuwp-plugin-thema-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Thema taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie
  * Description:         Plugin voor het aanmaken van de 'thema'-taxonomie
- * Version:             2.0.0
- * Version description: Refactor for Timber v2
+ * Version:             2.0.1
+ * Version description: Lowercase the 1st character of the Thema tax name in archive link text
  * Author:              Paul van Buuren
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie/
  * License:             GPL-2.0+

--- a/template-thema-detail.php
+++ b/template-thema-detail.php
@@ -417,8 +417,8 @@ if ( $metabox_fields && 'ja' === $metabox_fields['metabox_posts_show_or_not'] ) 
 					$metabox_posts_category_name = $term_info->name;
 					$metabox_posts_category_text = $metabox_fields['metabox_posts_archive_selection_automatic_link_text'] ?: _x( 'Bekijk alle berichten', 'Linktekst voor Community berichten', 'gctheme' );
 
-					// Replace placeholder with term name in automatic link text
-					$metabox_posts_category_text = sprintf( $metabox_posts_category_text, $metabox_posts_category_name );
+					// Replace placeholder with term name (lowercase 1st character) in automatic link text
+					$metabox_posts_category_text = sprintf( $metabox_posts_category_text, lcfirst( $metabox_posts_category_name ) );
 
 					// automagically add link to LLK page for posts
 					$template = 'template-llk-posts.php';


### PR DESCRIPTION
Currently the (automatic) link-text in the Thema post-archives is: `"Alle artikelen onder '%s'"` which becomes e.g. "Alle artikelen onder 'Begrijpelijke tekst en beeldtaal'".

We've changed this in [NPR PR 652](https://github.com/ICTU/ictuwp-gebruikercentraal/pull/652) to `"Alle artikelen over %s"` ("Alle artikelen over Begrijpelijke tekst en beeldtaal") but do not wat the capitalized Thema name. It should be "begrijpelijke tekst en beeldtaal" in running text.

So this PR fixes that capitalization issue.