### PR TITLE
`v2.2.1` Fix: search result should not go to first `$post` match.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version history
+* 2.2.1 - Fix: search result should not go to first `$post` match.
 * 2.2.0 - Return no Thema tax terms if ALL available are coupled to post
 * 2.0.1 - Lowercase the 1st character of the Thema tax name in archive link text
 * 2.0.0 - Refactor for Timber v2

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Plugin voor het aanmaken van de 'thema'-taxonomie
 
 
 ## Current version:
-* 2.2.0 - Return no Thema tax terms if ALL available are coupled to post
+* 2.2.1 - Fix: search result should not go to first `$post` match.
 
 ## Changelog:
+* 2.2.0 - Return no Thema tax terms if ALL available are coupled to post
 * 2.0.1 - Lowercase the 1st character of the Thema tax name in archive link text
 * 2.0.0 - Refactor for Timber v2
 * 1.2.20 - Force new version

--- a/ictuwp-plugin-thema-taxonomie.php
+++ b/ictuwp-plugin-thema-taxonomie.php
@@ -8,8 +8,8 @@
  * Plugin Name:         ICTU / Gebruiker Centraal / Thema taxonomie
  * Plugin URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie
  * Description:         Plugin voor het aanmaken van de 'thema'-taxonomie
- * Version:             2.2.0
- * Version description: Return no Thema tax terms if ALL available are coupled to post
+ * Version:             2.2.1
+ * Version description: Fix: search result should not go to first `$post` match.
  * Author:              Paul van Buuren
  * Author URI:          https://github.com/ICTU/ictuwp-plugin-thema-taxonomie/
  * License:             GPL-2.0+
@@ -174,6 +174,11 @@ if ( ! class_exists( 'ICTU_GC_thema_taxonomy' ) ) :
 		 *
 		 */
 		public function fn_ictu_thema_append_template_locations( $template ) {
+
+			if ( is_search() ) {
+				// Do not interfere with search results
+				return $template;
+			}
 
 			// Get global post
 			global $post;


### PR DESCRIPTION
Bug: https://www.gebruikercentraal.nl/?s=empathie gaat direct naar de Themapagina 'Mens­gericht denken en ont­werpen'.

De reden — denk ik — is dat de Thema functionaliteit gebruik maakt van de **global** `$post` en vervolgens het WordPress `$template` overschrijft...

De globale `$post` wordt schijnbaar gezet als het eerste (en enige?) zoek-resultaat.
